### PR TITLE
Added explainable tanimoto similarity with MACCS keys. (closes #2)

### DIFF
--- a/config/experiments/tanimoto_similarity.yaml
+++ b/config/experiments/tanimoto_similarity.yaml
@@ -1,0 +1,25 @@
+experiment_name: tanimoto_similarity_optimization
+
+log_dir: data/runs
+recursion_limit: 100
+
+llm:
+  model: gpt-5.1
+  temperature: 0.3
+  api_key_env: OPENAI_API_KEY
+  # base_url: https://custom-endpoint.example.com/v1  # Uncomment for custom endpoint
+
+oracle:
+  name: tanimoto_similarity
+  params:
+    # Target molecule: Aspirin (acetylsalicylic acid)
+    target_smiles: "CC(=O)Oc1ccccc1C(=O)O"
+
+objective:
+  name: tanimoto_similarity
+  params:
+    # Must match oracle's target_smiles for first_message prompt
+    target_smiles: "CC(=O)Oc1ccccc1C(=O)O"
+    target_similarity: 0.9
+    max_iterations: 20
+

--- a/src/molopt_agent/objectives/__init__.py
+++ b/src/molopt_agent/objectives/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from .base import Objective
 from .opioid_ki import OpioidKiObjective
 from .qed import QedObjective
+from .tanimoto_similarity import TanimotoSimilarityObjective
 from ..config import ObjectiveConfig
 from ..oracles.base import Oracle
 
@@ -10,6 +11,7 @@ from ..oracles.base import Oracle
 OBJECTIVE_REGISTRY: Dict[str, Type[Objective]] = {
     "opioid_ki": OpioidKiObjective,
     "qed": QedObjective,
+    "tanimoto_similarity": TanimotoSimilarityObjective,
 }
 
 

--- a/src/molopt_agent/objectives/opioid_ki.py
+++ b/src/molopt_agent/objectives/opioid_ki.py
@@ -51,7 +51,7 @@ Evaluation of your last proposal:
 
 SMILES: {state['current_smiles']}
 Predicted Ki: {ki:.2f} nM (lower is better)
-Target: Ki < {self._target_ki_nM:.2f} nM.
+Goal: Ki < {self._target_ki_nM:.2f} nM.
 Iteration: {state['iteration_count']} / {self._max_iterations}
 
 Oracle explanation:

--- a/src/molopt_agent/objectives/qed.py
+++ b/src/molopt_agent/objectives/qed.py
@@ -53,7 +53,8 @@ class QedObjective:
 
         return f"""
 SMILES: {state['current_smiles']}
-QED: {qed_score:.3f} / {self._target_qed:.2f} (target)
+QED: {qed_score:.3f}
+Goal: achieve QED ≥ {self._target_qed:.2f}
 Iteration: {state['iteration_count']} / {self._max_iterations}
 
 {explanation}

--- a/src/molopt_agent/objectives/tanimoto_similarity.py
+++ b/src/molopt_agent/objectives/tanimoto_similarity.py
@@ -1,0 +1,113 @@
+from ..oracles.base import Oracle, OracleResult
+from ..state import WorkflowState
+
+
+FIRST_MESSAGE_TEMPLATE = """
+We are optimizing molecules for structural similarity to a target molecule using MACCS fingerprints and Tanimoto similarity.
+
+Target molecule SMILES: {target_smiles}
+
+Objective:
+- Maximize Tanimoto similarity to the target (range 0-1, higher is better).
+- Target: similarity ≥ {target_similarity:.2f}
+- IMPORTANT: You must propose molecules that are STRUCTURALLY DIFFERENT from the target. Proposing the exact same molecule as the target is not allowed.
+
+The oracle evaluates similarity using 166 MACCS keys, which encode presence/absence of specific structural features (functional groups, ring systems, atom types, etc.). 
+You will receive feedback on which structural features are missing or extra compared to the target.
+
+Step 1:
+Propose a single initial molecule as a SMILES string that you expect to be structurally similar to the target, but NOT identical.
+
+Respond with a single JSON object:
+{{
+  "reason": "<why this molecule should be similar to the target>",
+  "smiles": "<SMILES string - must be different from target>"
+}}
+""".strip()
+
+
+class TanimotoSimilarityObjective:
+    """Objective for maximizing Tanimoto similarity to a target molecule using MACCS keys."""
+
+    name = "tanimoto_similarity"
+
+    def __init__(
+        self, 
+        oracle: Oracle, 
+        target_smiles: str,
+        target_similarity: float = 0.9, 
+        max_iterations: int = 20
+    ):
+        self.oracle = oracle
+        self._target_smiles = target_smiles
+        self._target_similarity = float(target_similarity)
+        self._max_iterations = int(max_iterations)
+
+    def first_message(self) -> str:
+        return FIRST_MESSAGE_TEMPLATE.format(
+            target_smiles=self._target_smiles,
+            target_similarity=self._target_similarity,
+        )
+
+    def evaluate(self, state: WorkflowState) -> OracleResult:
+        smiles = state["current_smiles"]
+        return self.oracle(smiles)
+
+    def build_feedback(self, state: WorkflowState, result: OracleResult) -> str:
+        similarity = result["score"]
+        explanation = result["explanation"]
+
+        # Check if molecule is identical to target
+        is_identical = "IDENTICAL MOLECULE" in explanation
+
+        feedback = f"""
+Evaluation of your proposal:
+
+SMILES: {state['current_smiles']}
+Tanimoto Similarity: {similarity:.4f}
+Goal: achieve similarity ≥ {self._target_similarity:.2f}
+Iteration: {state['iteration_count']} / {self._max_iterations}
+
+{explanation}
+"""
+
+        if is_identical:
+            feedback += """
+WARNING: You proposed the exact target molecule. This is NOT allowed.
+The similarity score was set to 0.0 because identical molecules are not accepted.
+You must propose a molecule that is structurally SIMILAR but NOT IDENTICAL to the target.
+"""
+
+        feedback += """
+Based on the MACCS key differences above, propose a modified molecule that:
+1. Adds missing structural features (if any)
+2. Removes extra structural features (if any)
+3. Is NOT identical to the target molecule
+
+Respond with JSON only:
+{
+  "reason": "<what structural changes you made and why>",
+  "smiles": "<new SMILES - must be different from both target and previous proposals>"
+}
+"""
+        return feedback.strip()
+
+    def is_done(self, state: WorkflowState, result: OracleResult) -> bool:
+        # Hard iteration cap
+        if state["iteration_count"] >= self._max_iterations:
+            return True
+
+        # Check for identical molecule (not allowed as success)
+        if "IDENTICAL MOLECULE" in result.get("explanation", ""):
+            return False
+
+        # Success: similarity meets target (and not identical)
+        similarity = result["score"]
+        if similarity is not None and similarity >= self._target_similarity:
+            return True
+
+        return False
+
+    def max_iterations(self) -> int:
+        return self._max_iterations
+

--- a/src/molopt_agent/oracles/__init__.py
+++ b/src/molopt_agent/oracles/__init__.py
@@ -3,12 +3,14 @@ from typing import Dict, Type
 from .base import Oracle, OracleResult
 from .opioid_ki import MolEncoderOpioidKiOracle
 from .qed import ExplainableQedOracle
+from .tanimoto_similarity import TanimotoSimilarityOracle
 from ..config import OracleConfig
 
 
 ORACLE_REGISTRY: Dict[str, Type[Oracle]] = {
     "opioid_ki": MolEncoderOpioidKiOracle,
     "qed": ExplainableQedOracle,
+    "tanimoto_similarity": TanimotoSimilarityOracle,
 }
 
 

--- a/src/molopt_agent/oracles/tanimoto_similarity.py
+++ b/src/molopt_agent/oracles/tanimoto_similarity.py
@@ -1,0 +1,123 @@
+from rdkit import Chem
+from rdkit.Chem import MACCSkeys
+from rdkit.Chem.MACCSkeys import smartsPatts
+from rdkit.Chem.inchi import MolToInchiKey
+from rdkit.DataStructs import TanimotoSimilarity
+
+from .base import OracleResult
+
+
+def _build_maccs_key_definitions() -> dict[int, str]:
+    """
+    Build MACCS key definitions from RDKit's smartsPatts.
+    
+    For most keys, uses the SMARTS pattern directly from RDKit.
+    For special keys (1, 125, 166) that use '?' placeholder, 
+    describes the RDKit function used instead.
+    """
+    definitions = {}
+    
+    for key, (smarts, count) in smartsPatts.items():
+        if smarts == '?':
+            # Special cases handled by RDKit functions, not SMARTS
+            if key == 1:
+                definitions[key] = "ISOTOPE (rdkit: mol.GetAtoms() isotope check)"
+            elif key == 125:
+                definitions[key] = "Aromatic Ring > 1 (rdkit: GetRingInfo().BondRings() aromaticity check)"
+            elif key == 166:
+                definitions[key] = "Fragments > 1 (rdkit: Chem.GetMolFrags(mol))"
+            else:
+                raise ValueError(f"Unexpected '?' placeholder for MACCS key {key}")
+        else:
+            # Use SMARTS pattern directly, with count threshold if applicable
+            if count > 0:
+                definitions[key] = f"{smarts} (count > {count})"
+            else:
+                definitions[key] = smarts
+    
+    return definitions
+
+
+MACCS_KEY_DEFINITIONS = _build_maccs_key_definitions()
+
+
+class TanimotoSimilarityOracle:
+    """
+    Oracle computing Tanimoto similarity using MACCS keys against a target molecule.
+    
+    Returns similarity score (0-1, higher = more similar) and explanation of 
+    which structural features differ between the query and target molecules.
+    """
+
+    def __init__(self, target_smiles: str):
+        self.target_smiles = target_smiles
+        self.target_mol = Chem.MolFromSmiles(target_smiles)
+        if self.target_mol is None:
+            raise ValueError(f"Invalid target SMILES: {target_smiles}")
+        self.target_fp = MACCSkeys.GenMACCSKeys(self.target_mol)
+        self.target_on_bits = set(self.target_fp.GetOnBits())
+        self.target_inchi_key = MolToInchiKey(self.target_mol)
+
+    def __call__(self, smiles: str) -> OracleResult:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            raise ValueError(f"Invalid SMILES: {smiles}")
+
+        # Check for identical molecule using InChIKey
+        query_inchi_key = MolToInchiKey(mol)
+        if query_inchi_key == self.target_inchi_key:
+            return {
+                "score": 0.0,
+                "explanation": "IDENTICAL MOLECULE - This is the target molecule itself. "
+                               "Please propose a structurally different molecule.",
+            }
+
+        fp = MACCSkeys.GenMACCSKeys(mol)
+        similarity = TanimotoSimilarity(self.target_fp, fp)
+
+        query_on_bits = set(fp.GetOnBits())
+
+        # Bits only in target (features missing from query)
+        missing_from_query = self.target_on_bits - query_on_bits
+        # Bits only in query (extra features not in target)
+        extra_in_query = query_on_bits - self.target_on_bits
+
+        explanation = self._build_explanation(similarity, missing_from_query, extra_in_query)
+
+        return {"score": similarity, "explanation": explanation}
+
+    def _build_explanation(
+        self, 
+        similarity: float, 
+        missing_from_query: set[int], 
+        extra_in_query: set[int]
+    ) -> str:
+        lines = [
+            f"Tanimoto Similarity (MACCS keys): {similarity:.4f}",
+            "",
+        ]
+
+        if not missing_from_query and not extra_in_query:
+            lines.append("All MACCS key bits match between query and target.")
+            return "\n".join(lines)
+
+        # Report features that reduce similarity
+        if missing_from_query:
+            lines.append(
+                f"The following {len(missing_from_query)} features are present in TARGET but not in QUERY (reducing similarity):"
+            )
+            for bit in sorted(missing_from_query):
+                desc = MACCS_KEY_DEFINITIONS.get(bit, f"MACCS_KEY_{bit}")
+                lines.append(f"  Key {bit}: {desc}")
+            lines.append("")
+
+        if extra_in_query:
+            lines.append(
+                f"The following {len(extra_in_query)} features are present in QUERY but not in TARGET (reducing similarity):"
+            )
+            for bit in sorted(extra_in_query):
+                desc = MACCS_KEY_DEFINITIONS.get(bit, f"MACCS_KEY_{bit}")
+                lines.append(f"  Key {bit}: {desc}")
+
+        return "\n".join(lines)
+


### PR DESCRIPTION
Added new oracle and objective.
Added them in model registry.
Adapted QED and Ki feedback to be consistent with new similarity first message.
Tested Tanimoto similarity optimization.
