### PR TITLE
Fix passing boltz2 binding probability from the oracle to the objective

### DIFF
--- a/src/molopt_agent/objectives/boltz2.py
+++ b/src/molopt_agent/objectives/boltz2.py
@@ -120,9 +120,8 @@ Do not include any additional text, comments, Markdown, or code fences.
         else:
             # Affinity mode: optimize affinity with probability constraint
             affinity = result["score"]
-            # parse probability from oracle explanation
-            explanation_json = json.loads(explanation) if explanation else {}
-            binding_probability = explanation_json.get("affinity_probability_binary", None)
+            # get binding probability from oracle explanation
+            binding_probability = result.get("affinity_probability_binary", None)
 
             probability_info = ""
             if binding_probability is not None:

--- a/src/molopt_agent/oracles/boltz2.py
+++ b/src/molopt_agent/oracles/boltz2.py
@@ -118,8 +118,7 @@ class Boltz2Oracle:
         # If using affinity mode, also include probability for constraint checking
         if self.binding_score_name == "affinity_pred_value":
             binding_prob = affinity_data["affinity_probability_binary"]
-            explanation_dict = {"affinity_probability_binary": binding_prob}
-            result["explanation"] = json.dumps(explanation_dict)
+            result["affinity_probability_binary"] = binding_prob
 
         logger.info(f"Boltz-2 prediction result: {result}")
 


### PR DESCRIPTION
return binding probability as additional key in the result from the oracle instead of parsing it from the the explanation string