### PR TITLE
Add unit tests, lean CI, and parse/validation hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      TRANSFORMERS_NO_TORCH: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install lean test dependencies
+        run: |
+          # Lean CI deps (no Boltz/GPU/TDC/pytorch). Unit tests cover parse/config/registry/routing.
+          uv pip install --system \
+            pytest pytest-cov pyyaml rdkit \
+            langchain-core
+          uv pip install --system -e .
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest -q \
+            --cov=molopt_agent \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=xml \
+            --cov-config=pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ skip_test.sh
 # pmo baseline
 data/results/pmo_baseline/*
 data/results/tdc_top_50_baselines/*
+# tests / coverage
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,43 @@ default = { features = [], solve-group = "default" }
 tdc = { features = ["tdc"], solve-group = "tdc", no-default-feature = true }
 boltz2 = { features = ["boltz2"], solve-group = "boltz2", no-default-feature = true }
 marimo = { features = ["marimo"], solve-group = "marimo", no-default-feature = true}
+
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-cov>=5.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["molopt_agent"]
+omit = [
+  "*/molopt_agent/ui/*",
+  "*/molopt_agent/main.py",
+  "*/molopt_agent/graph/builder.py",
+  "*/molopt_agent/graph/nodes.py",
+  "*/molopt_agent/save_experiment.py",
+  "*/molopt_agent/system_prompt.py",
+  "*/molopt_agent/oracles/boltz2.py",
+  "*/molopt_agent/oracles/tdc_tasks.py",
+  "*/molopt_agent/oracles/ic50mpro.py",
+  "*/molopt_agent/oracles/opioid_ki.py",
+  "*/molopt_agent/oracles/novel.py",
+  "*/molopt_agent/objectives/boltz2.py",
+  "*/molopt_agent/objectives/tdc_tasks.py",
+  "*/molopt_agent/objectives/ic50mpro*.py",
+  "*/molopt_agent/objectives/opioid_ki.py",
+  "*/molopt_agent/objectives/novel.py",
+  "*/molopt_agent/objectives/similarity*.py",
+  "*/molopt_agent/objectives/generic_messages.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+exclude_lines = [
+  "pragma: no cover",
+  "if __name__ == .__main__.:",
+]

--- a/src/molopt_agent/graph/__init__.py
+++ b/src/molopt_agent/graph/__init__.py
@@ -1,4 +1,19 @@
-from .builder import build_workflow
+"""Graph package.
+
+`build_workflow` is imported lazily so unit tests can load parse/routing helpers
+without pulling the LLM/builder stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["build_workflow"]
 
+
+def __getattr__(name: str) -> Any:
+    if name == "build_workflow":
+        from .builder import build_workflow
+
+        return build_workflow
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/molopt_agent/graph/nodes.py
+++ b/src/molopt_agent/graph/nodes.py
@@ -4,19 +4,18 @@ import os
 import random
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import httpcore
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
-from openai import APIConnectionError, APIStatusError, RateLimitError
-from rdkit import Chem
 
 from ..objectives.base import Objective
 from ..state import WorkflowState
+from .parsing import extract_json_object, parse_node, validation_node  # noqa: F401
+
+if TYPE_CHECKING:
+    from langchain_openai import ChatOpenAI
 
 logger = logging.getLogger(__name__)
-
 
 def _truncate_text(value: str, max_len: int = 800) -> str:
     if len(value) <= max_len:
@@ -82,7 +81,7 @@ def _sanitize_messages(messages: Any) -> Any:
     return [m for m in messages if not _message_content_is_blank(getattr(m, "content", None))]
 
 
-def _is_blank_content_gateway_error(error: APIStatusError) -> bool:
+def _is_blank_content_gateway_error(error: Any) -> bool:
     text = str(_serialize_error_body(getattr(error, "body", None)))
     return (
         "content': ''" in text
@@ -92,7 +91,7 @@ def _is_blank_content_gateway_error(error: APIStatusError) -> bool:
 
 
 def _write_api_error_log(
-    error: APIStatusError,
+    error: Any,
     messages: Any,
     attempt: int,
     max_attempts: int,
@@ -127,7 +126,10 @@ def _write_api_error_log(
     return log_path
 
 
-def rate_limit_sensible_llm_call(llm: ChatOpenAI, message, max_attempts=3):
+def rate_limit_sensible_llm_call(llm: "ChatOpenAI", message, max_attempts=3):
+    import httpcore
+    from openai import APIConnectionError, APIStatusError, RateLimitError
+
     delay = 60  # sensible default for hard limits
     conn_delay = 0.5
 
@@ -192,7 +194,7 @@ def rate_limit_sensible_llm_call(llm: ChatOpenAI, message, max_attempts=3):
             raise
 
 
-def make_generation_node(objective: Objective, llm: ChatOpenAI, system_prompt: str):
+def make_generation_node(objective: Objective, llm: "ChatOpenAI", system_prompt: str):
     def generation_node(state: WorkflowState) -> WorkflowState:
         iteration = state["iteration_count"] + 1  # +1 because we increment at the end
         logger.info(f"=== Starting Iteration {iteration} ===")
@@ -239,49 +241,6 @@ def make_generation_node(objective: Objective, llm: ChatOpenAI, system_prompt: s
         return state
 
     return generation_node
-
-
-def parse_node(state: WorkflowState) -> WorkflowState:
-    iteration = state["iteration_count"]
-    raw = state["raw_model_output"]
-    try:
-        parsed = json.loads(raw)
-        state["current_smiles"] = parsed["smiles"]
-        state["current_reason"] = parsed["reason"]
-        state["is_valid"] = True
-        state["validation_error"] = ""
-        logger.info(f"Iteration {iteration}: Parsed SMILES: {state['current_smiles']}")
-    except Exception as e:
-        state["current_smiles"] = ""
-        state["current_reason"] = ""
-        state["is_valid"] = False
-        state["validation_error"] = (
-            "Invalid JSON. Provide proper JSON with fields 'smiles' and 'reason'."
-        )
-        logger.error(
-            f"Iteration {iteration}: Failed to parse JSON from LLM output: {e}"
-        )
-    return state
-
-
-def validation_node(state: WorkflowState) -> WorkflowState:
-    iteration = state["iteration_count"]
-    smiles = state["current_smiles"]
-    try:
-        mol = Chem.MolFromSmiles(smiles)
-        if mol is None:
-            state["is_valid"] = False
-            state["validation_error"] = f"Invalid SMILES: {smiles}"
-            logger.error(f"Iteration {iteration}: Invalid SMILES string: {smiles}")
-        else:
-            state["is_valid"] = True
-            state["validation_error"] = ""
-            logger.info(f"Iteration {iteration}: SMILES validated successfully")
-    except Exception as e:
-        state["is_valid"] = False
-        state["validation_error"] = f"Validation error: {str(e)}"
-        logger.error(f"Iteration {iteration}: SMILES validation error: {e}")
-    return state
 
 
 def make_prediction_node(objective: Objective):
@@ -335,7 +294,7 @@ def make_prediction_node(objective: Objective):
     return prediction_node
 
 
-def make_final_response_node(llm: ChatOpenAI, xai_mode: str | None = None):
+def make_final_response_node(llm: "ChatOpenAI", xai_mode: str | None = None):
     def final_response_node(state: WorkflowState) -> WorkflowState:
         # Extract the objective description from the first human message
         objective_context = (

--- a/src/molopt_agent/graph/parsing.py
+++ b/src/molopt_agent/graph/parsing.py
@@ -1,0 +1,151 @@
+"""JSON extraction and SMILES parse/validation graph nodes."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from rdkit import Chem
+
+from ..state import WorkflowState
+
+logger = logging.getLogger(__name__)
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)```", re.IGNORECASE)
+
+
+def _loads_json_object(text: str) -> dict[str, Any]:
+    """Parse *text* as a JSON object; raise ValueError/JSONDecodeError otherwise."""
+    parsed = json.loads(text)
+    if not isinstance(parsed, dict):
+        raise ValueError("JSON payload must be an object")
+    return parsed
+
+
+def _slice_first_json_object(text: str) -> str | None:
+    """Return the first top-level `{...}` substring, respecting string literals."""
+    start = text.find("{")
+    if start < 0:
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def extract_json_object(raw: str) -> dict[str, Any]:
+    """Extract a JSON object from model output, tolerating fences and prose."""
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("empty model output")
+
+    try:
+        return _loads_json_object(text)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    fence = _JSON_FENCE_RE.search(text)
+    if fence:
+        try:
+            return _loads_json_object(fence.group(1).strip())
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    candidate = _slice_first_json_object(text)
+    if candidate is not None:
+        return _loads_json_object(candidate)
+
+    raise ValueError("no JSON object found in model output")
+
+
+def _require_string_field(payload: dict[str, Any], key: str) -> str:
+    if key not in payload:
+        raise ValueError(f"missing required field '{key}'")
+    value = payload[key]
+    if value is None:
+        raise ValueError(f"field '{key}' must not be null")
+    if not isinstance(value, str):
+        raise ValueError(f"field '{key}' must be a string")
+    return value.strip()
+
+
+def parse_node(state: WorkflowState) -> WorkflowState:
+    iteration = state["iteration_count"]
+    raw = state["raw_model_output"]
+    try:
+        parsed = extract_json_object(raw)
+        smiles = _require_string_field(parsed, "smiles")
+        reason = _require_string_field(parsed, "reason")
+        if not smiles:
+            raise ValueError("field 'smiles' must not be empty")
+        state["current_smiles"] = smiles
+        state["current_reason"] = reason
+        state["is_valid"] = True
+        state["validation_error"] = ""
+        logger.info(f"Iteration {iteration}: Parsed SMILES: {state['current_smiles']}")
+    except Exception as e:
+        state["current_smiles"] = ""
+        state["current_reason"] = ""
+        state["is_valid"] = False
+        state["validation_error"] = (
+            "Invalid JSON. Provide proper JSON with fields 'smiles' and 'reason'."
+        )
+        logger.error(
+            f"Iteration {iteration}: Failed to parse JSON from LLM output: {e}"
+        )
+    return state
+
+
+def validation_node(state: WorkflowState) -> WorkflowState:
+    iteration = state["iteration_count"]
+    smiles = state.get("current_smiles") or ""
+    if not isinstance(smiles, str):
+        smiles = str(smiles)
+    smiles = smiles.strip()
+    state["current_smiles"] = smiles
+
+    if not smiles:
+        state["is_valid"] = False
+        state["validation_error"] = "Invalid SMILES: empty string"
+        logger.error(f"Iteration {iteration}: Empty SMILES string")
+        return state
+
+    try:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            state["is_valid"] = False
+            state["validation_error"] = f"Invalid SMILES: {smiles}"
+            logger.error(f"Iteration {iteration}: Invalid SMILES string: {smiles}")
+        else:
+            state["is_valid"] = True
+            state["validation_error"] = ""
+            logger.info(f"Iteration {iteration}: SMILES validated successfully")
+    except Exception as e:
+        state["is_valid"] = False
+        state["validation_error"] = f"Validation error: {str(e)}"
+        logger.error(f"Iteration {iteration}: SMILES validation error: {e}")
+    return state
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest fixtures / env for lean unit tests."""
+
+from __future__ import annotations
+
+import os
+
+# Must run at import time so collection imports see this.
+os.environ["TRANSFORMERS_NO_TORCH"] = "1"
+
+
+def pytest_configure(config):  # noqa: ARG001
+    os.environ["TRANSFORMERS_NO_TORCH"] = "1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,214 @@
+"""Tests for experiment YAML config loading and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from molopt_agent.config import load_experiment_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QED_CONFIG = REPO_ROOT / "config" / "experiments" / "qed.yaml"
+
+
+def test_load_bundled_qed_config():
+    cfg = load_experiment_config(str(QED_CONFIG))
+    assert cfg.experiment_name == "qed_optimization"
+    assert cfg.llm.model == "claude-opus-4.5"
+    assert cfg.llm.temperature == 0.3
+    assert cfg.llm.reasoning_effort is None
+    assert cfg.oracle.name == "qed"
+    assert cfg.objective.name == "qed"
+    assert cfg.objective.params["target_qed"] == 0.9
+    assert cfg.recursion_limit == 100
+    assert cfg.log_dir == "data/runs"
+
+
+def test_load_config_missing_file():
+    with pytest.raises(ValueError, match="not found"):
+        load_experiment_config("/tmp/definitely-missing-seismo-config.yaml")
+
+
+def test_load_config_rejects_non_mapping(tmp_path: Path):
+    path = tmp_path / "bad.yaml"
+    path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Top-level"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_requires_top_level_keys(tmp_path: Path):
+    path = tmp_path / "partial.yaml"
+    path.write_text("experiment_name: x\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Missing required key"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_requires_llm_fields(tmp_path: Path):
+    path = tmp_path / "llm_bad.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+oracle:
+  name: qed
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="config.llm"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_accepts_reasoning_effort_none_string(tmp_path: Path):
+    path = tmp_path / "effort_none.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.2
+  reasoning_effort: None
+oracle:
+  name: qed
+  params: {}
+objective:
+  name: qed
+  params: {}
+""".strip(),
+        encoding="utf-8",
+    )
+    cfg = load_experiment_config(str(path))
+    assert cfg.llm.reasoning_effort is None
+
+
+def test_load_config_accepts_gpt_reasoning_effort(tmp_path: Path):
+    path = tmp_path / "effort_ok.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-5
+  temperature: 0.2
+  reasoning_effort: medium
+oracle:
+  name: qed
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    cfg = load_experiment_config(str(path))
+    assert cfg.llm.reasoning_effort == "medium"
+
+
+def test_load_config_rejects_invalid_reasoning_effort(tmp_path: Path):
+    path = tmp_path / "effort_bad.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.2
+  reasoning_effort: extreme
+oracle:
+  name: qed
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="reasoning_effort"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_requires_oracle_name(tmp_path: Path):
+    path = tmp_path / "oracle_bad.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.1
+oracle:
+  params: {}
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="oracle"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_rejects_non_dict_sections(tmp_path: Path):
+    path = tmp_path / "llm_list.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  - not-a-mapping
+oracle:
+  name: qed
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Config.llm"):
+        load_experiment_config(str(path))
+
+    path = tmp_path / "oracle_list.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.1
+oracle:
+  - qed
+objective:
+  name: qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Config.oracle"):
+        load_experiment_config(str(path))
+
+    path = tmp_path / "objective_list.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.1
+oracle:
+  name: qed
+objective:
+  - qed
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Config.objective"):
+        load_experiment_config(str(path))
+
+
+def test_load_config_requires_objective_name(tmp_path: Path):
+    path = tmp_path / "objective_bad.yaml"
+    path.write_text(
+        """
+experiment_name: x
+llm:
+  model: gpt-4o
+  temperature: 0.1
+oracle:
+  name: qed
+objective:
+  params: {}
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="objective"):
+        load_experiment_config(str(path))

--- a/tests/test_parse_validation.py
+++ b/tests/test_parse_validation.py
@@ -1,0 +1,185 @@
+"""Tests for SEISMO parse + SMILES validation nodes and JSON extraction helpers."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TRANSFORMERS_NO_TORCH", "1")
+
+import json
+
+import pytest
+
+rdkit = pytest.importorskip("rdkit")  # noqa: F401
+from molopt_agent.graph.parsing import (  # noqa: E402
+    extract_json_object,
+    parse_node,
+    validation_node,
+)
+from molopt_agent.state import make_initial_state  # noqa: E402
+
+
+def test_parse_node_accepts_valid_json():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps(
+        {"reason": "simple alcohol", "smiles": "CCO"}
+    )
+    out = parse_node(state)
+    assert out["is_valid"] is True
+    assert out["current_smiles"] == "CCO"
+    assert out["current_reason"] == "simple alcohol"
+    assert out["validation_error"] == ""
+
+
+def test_parse_node_rejects_invalid_json():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = "not json"
+    out = parse_node(state)
+    assert out["is_valid"] is False
+    assert out["current_smiles"] == ""
+    assert "JSON" in out["validation_error"]
+
+
+def test_parse_node_extracts_fenced_json():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = (
+        "Sure, here you go:\n"
+        "```json\n"
+        '{"reason": "benzene", "smiles": "c1ccccc1"}\n'
+        "```\n"
+    )
+    out = parse_node(state)
+    assert out["is_valid"] is True
+    assert out["current_smiles"] == "c1ccccc1"
+    assert out["current_reason"] == "benzene"
+
+
+def test_parse_node_extracts_json_embedded_in_prose():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = (
+        'Proposal: {"reason": "ethanol", "smiles": "CCO"} thanks.'
+    )
+    out = parse_node(state)
+    assert out["is_valid"] is True
+    assert out["current_smiles"] == "CCO"
+
+
+def test_parse_node_rejects_missing_fields():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps({"smiles": "CCO"})
+    out = parse_node(state)
+    assert out["is_valid"] is False
+    assert out["current_smiles"] == ""
+
+
+def test_parse_node_rejects_empty_smiles():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps({"reason": "empty", "smiles": "  "})
+    out = parse_node(state)
+    assert out["is_valid"] is False
+    assert out["current_smiles"] == ""
+
+
+def test_parse_node_rejects_non_object_json():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps(["CCO"])
+    out = parse_node(state)
+    assert out["is_valid"] is False
+
+
+def test_parse_node_strips_field_whitespace():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps(
+        {"reason": "  alcohol  ", "smiles": "  CCO  "}
+    )
+    out = parse_node(state)
+    assert out["is_valid"] is True
+    assert out["current_smiles"] == "CCO"
+    assert out["current_reason"] == "alcohol"
+
+
+def test_extract_json_object_prefers_direct_parse():
+    payload = {"reason": "x", "smiles": "C"}
+    assert extract_json_object(json.dumps(payload)) == payload
+
+
+def test_extract_json_object_handles_braces_inside_strings():
+    raw = 'prefix {"reason": "has {braces}", "smiles": "CCO"} trailing'
+    assert extract_json_object(raw) == {"reason": "has {braces}", "smiles": "CCO"}
+
+
+def test_validation_node_accepts_valid_smiles():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["current_smiles"] = "c1ccccc1"
+    out = validation_node(state)
+    assert out["is_valid"] is True
+    assert out["validation_error"] == ""
+
+
+def test_validation_node_rejects_invalid_smiles():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["current_smiles"] = "not_a_smiles"
+    out = validation_node(state)
+    assert out["is_valid"] is False
+    assert "Invalid SMILES" in out["validation_error"]
+
+
+def test_validation_node_rejects_empty_smiles():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["current_smiles"] = "   "
+    out = validation_node(state)
+    assert out["is_valid"] is False
+    assert "empty" in out["validation_error"].lower()
+
+
+def test_validation_node_strips_whitespace():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["current_smiles"] = "  CCO  "
+    out = validation_node(state)
+    assert out["is_valid"] is True
+    assert out["current_smiles"] == "CCO"
+
+
+
+def test_extract_json_object_rejects_empty():
+    with pytest.raises(ValueError, match="empty"):
+        extract_json_object("   ")
+
+
+def test_extract_json_object_unclosed_brace():
+    with pytest.raises(ValueError):
+        extract_json_object('prefix {"reason": "x"')
+
+
+def test_extract_json_object_skips_bad_fence_then_finds_object():
+    raw = "```json\nnot-json\n```\n" + '{"reason": "ok", "smiles": "CCO"}'
+    assert extract_json_object(raw) == {"reason": "ok", "smiles": "CCO"}
+
+
+def test_extract_json_object_handles_escaped_quotes():
+    raw = '{"reason": "say \\"hi\\"", "smiles": "CCO"}'
+    assert extract_json_object(raw)["reason"] == 'say "hi"'
+
+
+def test_parse_node_rejects_null_and_non_string_fields():
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps({"reason": None, "smiles": "CCO"})
+    assert parse_node(state)["is_valid"] is False
+
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["raw_model_output"] = json.dumps({"reason": "x", "smiles": 123})
+    assert parse_node(state)["is_valid"] is False

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,150 @@
+"""Tests for oracle/objective registry lookup (no heavy oracle execution)."""
+
+from __future__ import annotations
+
+import pytest
+
+rdkit = pytest.importorskip("rdkit")  # noqa: F401
+
+from molopt_agent.config import ObjectiveConfig, OracleConfig  # noqa: E402
+from molopt_agent.objectives import (  # noqa: E402
+    OBJECTIVE_REGISTRY,
+    build_objective_from_config,
+)
+from molopt_agent.oracles import ORACLE_REGISTRY, build_oracle_from_config  # noqa: E402
+from molopt_agent.oracles.composite import CompositeOracle  # noqa: E402
+from molopt_agent.state import make_initial_state  # noqa: E402
+
+
+def test_core_oracles_registered():
+    for name in ("qed", "similarity", "composite"):
+        assert name in ORACLE_REGISTRY
+
+
+def test_core_objectives_registered():
+    for name in ("qed", "similarity", "similarity_qed"):
+        assert name in OBJECTIVE_REGISTRY
+
+
+def test_build_qed_oracle_and_objective():
+    oracle = build_oracle_from_config(OracleConfig(name="qed", params={}))
+    objective = build_objective_from_config(
+        ObjectiveConfig(name="qed", params={"target_qed": 0.5, "max_iterations": 3}),
+        oracle=oracle,
+    )
+    assert objective.name == "qed"
+    assert objective.max_iterations() == 3
+
+    state = make_initial_state()
+    state["current_smiles"] = "CCO"
+    result = objective.evaluate(state)
+    assert 0.0 <= result["score"] <= 1.0
+    assert isinstance(result["explanation"], str)
+    assert "QED" in objective.first_message()
+
+
+def test_build_similarity_oracle():
+    oracle = build_oracle_from_config(
+        OracleConfig(name="similarity", params={"target_smiles": "CCO"})
+    )
+    result = oracle("CCO")
+    assert result["score"] == 0.0
+    assert "IDENTICAL" in result["explanation"]
+
+    result_other = oracle("c1ccccc1")
+    assert 0.0 <= result_other["score"] <= 1.0
+
+
+def test_unknown_oracle_raises():
+    with pytest.raises(ValueError, match="Unknown oracle"):
+        build_oracle_from_config(OracleConfig(name="not-an-oracle", params={}))
+
+
+def test_unknown_objective_raises():
+    oracle = build_oracle_from_config(OracleConfig(name="qed", params={}))
+    with pytest.raises(ValueError, match="Unknown objective"):
+        build_objective_from_config(
+            ObjectiveConfig(name="not-an-objective", params={}),
+            oracle=oracle,
+        )
+
+
+def test_composite_oracle_requires_nested_config():
+    with pytest.raises(ValueError, match="oracles"):
+        build_oracle_from_config(OracleConfig(name="composite", params={}))
+
+    with pytest.raises(ValueError, match="weights"):
+        build_oracle_from_config(
+            OracleConfig(
+                name="composite",
+                params={"oracles": [{"name": "qed", "params": {}}]},
+            )
+        )
+
+
+def test_build_composite_qed_similarity():
+    oracle = build_oracle_from_config(
+        OracleConfig(
+            name="composite",
+            params={
+                "oracles": [
+                    {"name": "qed", "params": {}},
+                    {"name": "similarity", "params": {"target_smiles": "CCO"}},
+                ],
+                "weights": [0.5, 0.5],
+                "names": ["qed", "sim"],
+            },
+        )
+    )
+    assert isinstance(oracle, CompositeOracle)
+    result = oracle("CCN")
+    assert "scores" in result
+    assert set(result["scores"]) == {"qed", "sim"}
+    assert 0.0 <= result["score"] <= 1.0
+
+
+def test_qed_objective_feedback_and_done():
+    oracle = build_oracle_from_config(OracleConfig(name="qed", params={}))
+    objective = build_objective_from_config(
+        ObjectiveConfig(name="qed", params={"target_qed": 0.01, "max_iterations": 2}),
+        oracle=oracle,
+    )
+    state = make_initial_state()
+    state["current_smiles"] = "CCO"
+    state["iteration_count"] = 1
+    result = objective.evaluate(state)
+    feedback = objective.build_feedback(state, result)
+    assert "QED:" in feedback
+    assert objective.is_done(state, result) is True  # low target
+
+    objective_hard = build_objective_from_config(
+        ObjectiveConfig(name="qed", params={"target_qed": 0.999, "max_iterations": 2}),
+        oracle=oracle,
+    )
+    assert objective_hard.is_done(state, result) is False
+    state["iteration_count"] = 2
+    assert objective_hard.is_done(state, result) is True
+
+
+def test_composite_oracle_direct_validation_errors():
+    qed = build_oracle_from_config(OracleConfig(name="qed", params={}))
+    with pytest.raises(ValueError, match="at least 2"):
+        CompositeOracle(oracles=[qed], weights=[1.0])
+    with pytest.raises(ValueError, match="weights"):
+        CompositeOracle(oracles=[qed, qed], weights=[1.0])
+    with pytest.raises(ValueError, match="names"):
+        CompositeOracle(oracles=[qed, qed], weights=[0.5, 0.5], names=["only_one"])
+
+
+def test_similarity_oracle_invalid_target():
+    with pytest.raises(ValueError, match="Invalid target SMILES"):
+        build_oracle_from_config(
+            OracleConfig(name="similarity", params={"target_smiles": "not_a_smiles"})
+        )
+
+
+def test_oracle_bad_constructor_params():
+    with pytest.raises(ValueError, match="Failed to construct oracle"):
+        build_oracle_from_config(
+            OracleConfig(name="similarity", params={"unexpected": True})
+        )

--- a/tests/test_routing_and_helpers.py
+++ b/tests/test_routing_and_helpers.py
@@ -1,0 +1,158 @@
+"""Tests for routing helpers and pure node utilities (no LLM/network)."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TRANSFORMERS_NO_TORCH", "1")
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from molopt_agent.graph import nodes as node_helpers
+from molopt_agent.graph import parsing as parsing_helpers
+from molopt_agent.graph.routing import (
+    make_route_after_parse,
+    make_route_after_prediction,
+    make_route_after_validation,
+)
+from molopt_agent.state import make_initial_state
+
+
+class _FakeObjective:
+    def __init__(self, max_iters: int = 3, done: bool = False):
+        self._max_iters = max_iters
+        self._done = done
+
+    def max_iterations(self) -> int:
+        return self._max_iters
+
+    def is_done(self, state, result) -> bool:
+        return self._done
+
+
+def test_route_after_parse_paths():
+    route = make_route_after_parse(_FakeObjective(max_iters=2))
+
+    state = make_initial_state()
+    state["iteration_count"] = 2
+    assert route(state) == "final"
+
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["is_valid"] = False
+    state["current_smiles"] = ""
+    assert route(state) == "generation"
+
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["is_valid"] = True
+    state["current_smiles"] = "CCO"
+    assert route(state) == "validation"
+
+
+def test_route_after_validation_paths():
+    route = make_route_after_validation(_FakeObjective(max_iters=2))
+
+    state = make_initial_state()
+    state["iteration_count"] = 2
+    assert route(state) == "final"
+
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["is_valid"] = True
+    assert route(state) == "prediction"
+
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["is_valid"] = False
+    assert route(state) == "generation"
+
+
+def test_route_after_prediction_paths():
+    route_done = make_route_after_prediction(_FakeObjective(max_iters=5, done=True))
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["oracle_result"] = {"score": 1.0}
+    assert route_done(state) == "final"
+
+    route_max = make_route_after_prediction(_FakeObjective(max_iters=2, done=False))
+    state = make_initial_state()
+    state["iteration_count"] = 2
+    state["oracle_result"] = {"score": 0.1}
+    assert route_max(state) == "final"
+
+    route_cont = make_route_after_prediction(_FakeObjective(max_iters=5, done=False))
+    state = make_initial_state()
+    state["iteration_count"] = 1
+    state["oracle_result"] = {"score": 0.1}
+    assert route_cont(state) == "generation"
+
+
+def test_truncate_text():
+    assert node_helpers._truncate_text("abc", 10) == "abc"
+    assert node_helpers._truncate_text("abcdefghij", 5).endswith("...[truncated]")
+
+
+def test_message_content_is_blank():
+    assert node_helpers._message_content_is_blank("") is True
+    assert node_helpers._message_content_is_blank("  ") is True
+    assert node_helpers._message_content_is_blank("hi") is False
+    assert (
+        node_helpers._message_content_is_blank(
+            [{"type": "text", "text": "  "}, {"type": "text", "text": ""}]
+        )
+        is True
+    )
+    assert (
+        node_helpers._message_content_is_blank([{"type": "text", "text": "ok"}])
+        is False
+    )
+    assert node_helpers._message_content_is_blank([{"type": "image"}]) is False
+
+
+def test_sanitize_messages_drops_blank():
+    messages = [
+        HumanMessage(content="keep"),
+        HumanMessage(content="   "),
+        HumanMessage(content="also keep"),
+    ]
+    cleaned = node_helpers._sanitize_messages(messages)
+    assert len(cleaned) == 2
+    assert cleaned[0].content == "keep"
+
+
+def test_serialize_error_body_and_blank_gateway_detection():
+    assert node_helpers._serialize_error_body(None) is None
+    assert node_helpers._serialize_error_body({"a": 1}) == {"a": 1}
+    assert isinstance(node_helpers._serialize_error_body({1, 2}), str)
+
+    err = SimpleNamespace(body={"content": ""})
+    assert node_helpers._is_blank_content_gateway_error(err) is True
+
+    err2 = SimpleNamespace(body={"detail": "text field may not be blank"})
+    assert node_helpers._is_blank_content_gateway_error(err2) is True
+
+    err3 = SimpleNamespace(body={"ok": True})
+    assert node_helpers._is_blank_content_gateway_error(err3) is False
+
+
+def test_cli_parse_args(monkeypatch: pytest.MonkeyPatch):
+    from molopt_agent.cli.args import parse_args
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["molopt", "--config", "config/experiments/qed.yaml"],
+    )
+    args = parse_args()
+    assert args.config == "config/experiments/qed.yaml"
+
+
+def test_make_initial_state_defaults():
+    state = make_initial_state()
+    assert state["messages"] == []
+    assert state["iteration_count"] == 0
+    assert state["is_valid"] is False
+    assert state["trace"] == []


### PR DESCRIPTION
## Summary
- Harden JSON/SMILES parse & validation: extract fenced/prose JSON, require non-empty string fields, strip whitespace; move helpers into `graph/parsing.py` (re-exported from `graph/nodes.py`).
- Add unit tests for parse/validation, config YAML loading, oracle/objective registry lookup (qed/similarity/composite), routing, and pure node helpers — no Boltz/TDC/GPU.
- Add GitHub Actions CI (`pytest` + `pytest-cov`) with lean pip deps (rdkit, langchain-core, pyyaml); lazy `build_workflow` import to keep unit imports light.

## Coverage (local)
- **51 passed**
- **~93%** on the unit-testable surface configured in `pyproject.toml` (`[tool.coverage.run] omit`)
- **Intentional exclusions:** UI, `main`, graph builder, LLM-heavy `graph/nodes.py` (generation/rate-limit/final summary), Boltz/TDC/ic50mpro/opioid/novel oracles & matching heavy objectives, `save_experiment`
- **Highlights:** `graph/parsing.py` ~93%; config/state/routing/cli.args/qed objective at or near 100%; lightweight oracles ~86–97%

## Test plan
- [ ] CI green on this PR
- [ ] Local: `TRANSFORMERS_NO_TORCH=1 pytest -q --cov=molopt_agent --cov-config=pyproject.toml`
- [ ] Spot-check that existing workflows still import `parse_node` / `validation_node` from `molopt_agent.graph.nodes`


Made with [Cursor](https://cursor.com)